### PR TITLE
Blog audit: security fixes, SEO meta tags, post preview, view count & social sharing

### DIFF
--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -56,6 +56,8 @@ class BlogController extends Controller
 
         $post = Cache::remember($cacheKey, now()->addMinutes(10), fn () => $post->load('categories', 'user'));
 
+        $post->increment('views');
+
         $relatedPosts = Post::published()
             ->with(['categories', 'user'])
             ->whereHas('categories', fn ($q) => $q->whereIn(

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -23,6 +23,7 @@ class DashboardController extends Controller
             'publishedPosts' => (clone $postQuery)->where('status', PostStatus::Published)->count(),
             'draftPosts' => (clone $postQuery)->where('status', PostStatus::Draft)->count(),
             'totalCategories' => Category::count(),
+            'totalViews' => (clone $postQuery)->sum('views'),
         ];
 
         $recentPosts = (clone $postQuery)

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -19,9 +19,7 @@ class PostController extends Controller
 {
     use AuthorizesRequests;
 
-    public function __construct(private ImageOptimizer $imageOptimizer)
-    {
-    }
+    public function __construct(private ImageOptimizer $imageOptimizer) {}
 
     public function index(Request $request): Response
     {
@@ -32,9 +30,9 @@ class PostController extends Controller
         $status = $request->string('status')->toString();
 
         $posts = Post::query()
-            ->when(!$user->isAdmin(), fn($q) => $q->forUser($user))
-            ->when($search, fn($q) => $q->search($search))
-            ->when($status, fn($q) => $q->where('status', $status))
+            ->when(! $user->isAdmin(), fn ($q) => $q->forUser($user))
+            ->when($search, fn ($q) => $q->search($search))
+            ->when($status, fn ($q) => $q->where('status', $status))
             ->with('categories')
             ->latest()
             ->paginate(15)
@@ -76,7 +74,7 @@ class PostController extends Controller
 
         $post = $request->user()->posts()->create($data);
 
-        if (!empty($data['category_ids'])) {
+        if (! empty($data['category_ids'])) {
             $post->categories()->sync($data['category_ids']);
         }
 
@@ -144,6 +142,29 @@ class PostController extends Controller
 
         return redirect()->route('posts.index')
             ->with('flash.success', 'Post deleted successfully.');
+    }
+
+    public function preview(Post $post): Response
+    {
+        $this->authorize('update', $post);
+
+        $post->load('categories', 'user');
+
+        $relatedPosts = Post::published()
+            ->with(['categories', 'user'])
+            ->whereHas('categories', fn ($q) => $q->whereIn(
+                'categories.id',
+                $post->categories->pluck('id')
+            ))
+            ->where('id', '!=', $post->id)
+            ->limit(3)
+            ->get();
+
+        return Inertia::render('blog/Show', [
+            'post' => $post,
+            'relatedPosts' => $relatedPosts,
+            'isPreview' => true,
+        ]);
     }
 
     public function autosave(UpdatePostRequest $request, Post $post): JsonResponse

--- a/app/Http/Middleware/SecureHeaders.php
+++ b/app/Http/Middleware/SecureHeaders.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecureHeaders
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->headers->set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+
+        if ($request->secure()) {
+            $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+        }
+
+        return $response;
+    }
+}

--- a/app/Http/Requests/Posts/StorePostRequest.php
+++ b/app/Http/Requests/Posts/StorePostRequest.php
@@ -14,6 +14,13 @@ class StorePostRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('content')) {
+            $this->merge(['content' => clean($this->input('content'), 'blog')]);
+        }
+    }
+
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
      */

--- a/app/Http/Requests/Posts/UpdatePostRequest.php
+++ b/app/Http/Requests/Posts/UpdatePostRequest.php
@@ -14,6 +14,13 @@ class UpdatePostRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('content')) {
+            $this->merge(['content' => clean($this->input('content'), 'blog')]);
+        }
+    }
+
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
      */

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\SecureHeaders;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -19,6 +20,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
 
         $middleware->web(append: [
+            SecureHeaders::class,
             HandleAppearance::class,
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "laravel/tinker": "^2.11",
         "laravel/wayfinder": "^0.1.14",
         "league/flysystem-aws-s3-v3": "^3.0",
+        "mews/purifier": "*",
         "resend/resend-laravel": "^1.3"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec65571c896f224de2cd6b7096e8aeda",
+    "content-hash": "5f6fc6f108a4bc926ad279bfdd1ad65b",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -763,6 +763,67 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/b287d2a16aceffbf6e0295559b39662612b77fcf",
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "cerdic/css-tidy": "^1.7 || ^2.0",
+                "simpletest/simpletest": "dev-master"
+            },
+            "suggest": {
+                "cerdic/css-tidy": "If you want to use the filter 'Filter.ExtractStyleBlocks'.",
+                "ext-bcmath": "Used for unit conversion and imagecrash protection",
+                "ext-iconv": "Converts text to and from non-UTF-8 encodings",
+                "ext-tidy": "Used for pretty-printing HTML"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ],
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "exclude-from-classmap": [
+                    "/library/HTMLPurifier/Language/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "support": {
+                "issues": "https://github.com/ezyang/htmlpurifier/issues",
+                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.19.0"
+            },
+            "time": "2025-10-17T16:34:55+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -2669,6 +2730,84 @@
                 }
             ],
             "time": "2026-01-15T06:54:53+00:00"
+        },
+        {
+            "name": "mews/purifier",
+            "version": "3.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mewebstudio/Purifier.git",
+                "reference": "acc71bc512dcf9b87144546d0e3055fc76d244ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mewebstudio/Purifier/zipball/acc71bc512dcf9b87144546d0e3055fc76d244ff",
+                "reference": "acc71bc512dcf9b87144546d0e3055fc76d244ff",
+                "shasum": ""
+            },
+            "require": {
+                "ezyang/htmlpurifier": "^4.16.0",
+                "illuminate/config": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/filesystem": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "graham-campbell/testbench": "^3.2|^5.5.1|^6.1",
+                "mockery/mockery": "^1.3.3",
+                "phpunit/phpunit": "^8.0|^9.0|^10.0"
+            },
+            "suggest": {
+                "laravel/framework": "To test the Laravel bindings",
+                "laravel/lumen-framework": "To test the Lumen bindings"
+            },
+            "type": "package",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Purifier": "Mews\\Purifier\\Facades\\Purifier"
+                    },
+                    "providers": [
+                        "Mews\\Purifier\\PurifierServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Mews\\Purifier\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Muharrem ERİN",
+                    "email": "me@mewebstudio.com",
+                    "homepage": "https://github.com/mewebstudio",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel 5/6/7/8/9/10 HtmlPurifier Package",
+            "homepage": "https://github.com/mewebstudio/purifier",
+            "keywords": [
+                "Laravel Purifier",
+                "Laravel Security",
+                "Purifier",
+                "htmlpurifier",
+                "laravel HtmlPurifier",
+                "security",
+                "xss"
+            ],
+            "support": {
+                "issues": "https://github.com/mewebstudio/Purifier/issues",
+                "source": "https://github.com/mewebstudio/Purifier/tree/3.4.3"
+            },
+            "time": "2025-02-24T16:00:29+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -9678,5 +9817,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/purifier.php
+++ b/config/purifier.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * Ok, glad you are here
+ * first we get a config instance, and set the settings
+ * $config = HTMLPurifier_Config::createDefault();
+ * $config->set('Core.Encoding', $this->config->get('purifier.encoding'));
+ * $config->set('Cache.SerializerPath', $this->config->get('purifier.cachePath'));
+ * if ( ! $this->config->get('purifier.finalize')) {
+ *     $config->autoFinalize = false;
+ * }
+ * $config->loadArray($this->getConfig());
+ *
+ * You must NOT delete the default settings
+ * anything in settings should be compacted with params that needed to instance HTMLPurifier_Config.
+ *
+ * @link http://htmlpurifier.org/live/configdoc/plain.html
+ */
+
+return [
+    'encoding' => 'UTF-8',
+    'finalize' => true,
+    'ignoreNonStrings' => false,
+    'cachePath' => storage_path('app/purifier'),
+    'cacheFileMode' => 0755,
+    'settings' => [
+        'default' => [
+            'HTML.Doctype' => 'HTML 4.01 Transitional',
+            'HTML.Allowed' => 'div,b,strong,i,em,u,a[href|title],ul,ol,li,p[style],br,span[style],img[width|height|alt|src]',
+            'CSS.AllowedProperties' => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
+            'AutoFormat.AutoParagraph' => true,
+            'AutoFormat.RemoveEmpty' => true,
+        ],
+        'blog' => [
+            'HTML.Doctype' => 'HTML 4.01 Transitional',
+            'HTML.Allowed' => implode(',', [
+                'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+                'p', 'br', 'hr',
+                'strong', 'b', 'em', 'i', 'u', 's', 'mark', 'sub', 'sup',
+                'a[href|title|target|rel]',
+                'ul', 'ol', 'li',
+                'blockquote', 'pre', 'code',
+                'img[src|alt|title|width|height]',
+                'table', 'thead', 'tbody', 'tfoot', 'tr', 'th[scope]', 'td',
+                'div', 'span',
+                'figure', 'figcaption',
+            ]),
+            'CSS.AllowedProperties' => '',
+            'AutoFormat.RemoveEmpty' => false,
+            'Attr.AllowedRel' => 'noopener,noreferrer,nofollow',
+        ],
+        'test' => [
+            'Attr.EnableID' => 'true',
+        ],
+        'youtube' => [
+            'HTML.SafeIframe' => 'true',
+            'URI.SafeIframeRegexp' => '%^(http://|https://|//)(www.youtube.com/embed/|player.vimeo.com/video/)%',
+        ],
+        'custom_definition' => [
+            'id' => 'html5-definitions',
+            'rev' => 1,
+            'debug' => false,
+            'elements' => [
+                // http://developers.whatwg.org/sections.html
+                ['section', 'Block', 'Flow', 'Common'],
+                ['nav',     'Block', 'Flow', 'Common'],
+                ['article', 'Block', 'Flow', 'Common'],
+                ['aside',   'Block', 'Flow', 'Common'],
+                ['header',  'Block', 'Flow', 'Common'],
+                ['footer',  'Block', 'Flow', 'Common'],
+
+                // Content model actually excludes several tags, not modelled here
+                ['address', 'Block', 'Flow', 'Common'],
+                ['hgroup', 'Block', 'Required: h1 | h2 | h3 | h4 | h5 | h6', 'Common'],
+
+                // http://developers.whatwg.org/grouping-content.html
+                ['figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common'],
+                ['figcaption', 'Inline', 'Flow', 'Common'],
+
+                // http://developers.whatwg.org/the-video-element.html#the-video-element
+                ['video', 'Block', 'Optional: (source, Flow) | (Flow, source) | Flow', 'Common', [
+                    'src' => 'URI',
+                    'type' => 'Text',
+                    'width' => 'Length',
+                    'height' => 'Length',
+                    'poster' => 'URI',
+                    'preload' => 'Enum#auto,metadata,none',
+                    'controls' => 'Bool',
+                ]],
+                ['source', 'Block', 'Flow', 'Common', [
+                    'src' => 'URI',
+                    'type' => 'Text',
+                ]],
+
+                // http://developers.whatwg.org/text-level-semantics.html
+                ['s',    'Inline', 'Inline', 'Common'],
+                ['var',  'Inline', 'Inline', 'Common'],
+                ['sub',  'Inline', 'Inline', 'Common'],
+                ['sup',  'Inline', 'Inline', 'Common'],
+                ['mark', 'Inline', 'Inline', 'Common'],
+                ['wbr',  'Inline', 'Empty', 'Core'],
+
+                // http://developers.whatwg.org/edits.html
+                ['ins', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']],
+                ['del', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']],
+            ],
+            'attributes' => [
+                ['iframe', 'allowfullscreen', 'Bool'],
+                ['table', 'height', 'Text'],
+                ['td', 'border', 'Text'],
+                ['th', 'border', 'Text'],
+                ['tr', 'width', 'Text'],
+                ['tr', 'height', 'Text'],
+                ['tr', 'border', 'Text'],
+            ],
+        ],
+        'custom_attributes' => [
+            ['a', 'target', 'Enum#_blank,_self,_target,_top'],
+        ],
+        'custom_elements' => [
+            ['u', 'Inline', 'Inline', 'Common'],
+        ],
+    ],
+
+];

--- a/database/migrations/2026_03_07_221038_add_views_to_posts_table.php
+++ b/database/migrations/2026_03_07_221038_add_views_to_posts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->unsignedBigInteger('views')->default(0)->after('published_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('views');
+        });
+    }
+};

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Head, Link } from '@inertiajs/vue3';
-import { FileText, Tag } from 'lucide-vue-next';
+import { Eye, FileText, Tag } from 'lucide-vue-next';
 import { Badge } from '@/components/ui/badge';
 import {
     Card,
@@ -30,6 +30,7 @@ defineProps<{
         publishedPosts: number;
         draftPosts: number;
         totalCategories: number;
+        totalViews: number;
     };
     recentPosts: Post[];
     popularCategories: Category[];
@@ -47,7 +48,7 @@ const breadcrumbs: BreadcrumbItem[] = [
     <AppLayout :breadcrumbs="breadcrumbs">
         <div class="flex flex-col gap-6 p-6">
             <!-- Stat cards -->
-            <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
                 <Card>
                     <CardHeader class="pb-2">
                         <CardDescription>Total Posts</CardDescription>
@@ -104,6 +105,23 @@ const breadcrumbs: BreadcrumbItem[] = [
                         >
                             <Tag class="size-3" />
                             Content categories
+                        </p>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader class="pb-2">
+                        <CardDescription>Total Views</CardDescription>
+                        <CardTitle class="text-3xl">{{
+                            stats.totalViews
+                        }}</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <p
+                            class="flex items-center gap-1 text-xs text-muted-foreground"
+                        >
+                            <Eye class="size-3" />
+                            All-time page views
                         </p>
                     </CardContent>
                 </Card>

--- a/resources/js/pages/blog/Show.vue
+++ b/resources/js/pages/blog/Show.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Head, Link } from '@inertiajs/vue3';
-import { ArrowLeft, Clock } from 'lucide-vue-next';
+import { ArrowLeft, Check, Clock, Copy, Link as LinkIcon } from 'lucide-vue-next';
+import { computed, ref } from 'vue';
 import BlogHeader from '@/components/BlogHeader.vue';
 import { Badge } from '@/components/ui/badge';
 import { formatDateLong } from '@/lib/date';
@@ -8,12 +9,23 @@ import { sanitizeHtml } from '@/lib/sanitize';
 import { index as blogIndex, show as blogShow } from '@/routes/blog';
 import type { Post } from '@/types';
 
-defineProps<{
+const props = defineProps<{
     post: Post;
     relatedPosts: Post[];
     isPreview?: boolean;
 }>();
 
+const shareUrl = computed(() => encodeURIComponent(window.location.href));
+const shareTitle = computed(() => encodeURIComponent(props.post.meta_title ?? props.post.title));
+
+const copied = ref(false);
+function copyLink() {
+    navigator.clipboard.writeText(window.location.href);
+    copied.value = true;
+    setTimeout(() => {
+        copied.value = false;
+    }, 2000);
+}
 </script>
 
 <template>
@@ -109,6 +121,110 @@ defineProps<{
                 class="prose dark:prose-invert prose-lg max-w-none"
                 v-html="sanitizeHtml(post.content)"
             />
+
+            <!-- Share buttons -->
+            <section class="mt-12 border-t pt-8">
+                <h2 class="mb-4 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+                    Share this post
+                </h2>
+                <div class="flex flex-wrap gap-2">
+                    <!-- X / Twitter -->
+                    <a
+                        :href="`https://twitter.com/intent/tweet?url=${shareUrl}&text=${shareTitle}`"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted"
+                        aria-label="Share on X / Twitter"
+                    >
+                        <svg class="size-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.742l7.733-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                        </svg>
+                        X / Twitter
+                    </a>
+
+                    <!-- LinkedIn -->
+                    <a
+                        :href="`https://www.linkedin.com/sharing/share-offsite/?url=${shareUrl}`"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted"
+                        aria-label="Share on LinkedIn"
+                    >
+                        <svg class="size-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+                        </svg>
+                        LinkedIn
+                    </a>
+
+                    <!-- Facebook -->
+                    <a
+                        :href="`https://www.facebook.com/sharer/sharer.php?u=${shareUrl}`"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted"
+                        aria-label="Share on Facebook"
+                    >
+                        <svg class="size-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+                        </svg>
+                        Facebook
+                    </a>
+
+                    <!-- Reddit -->
+                    <a
+                        :href="`https://www.reddit.com/submit?url=${shareUrl}&title=${shareTitle}`"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted"
+                        aria-label="Share on Reddit"
+                    >
+                        <svg class="size-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z" />
+                        </svg>
+                        Reddit
+                    </a>
+
+                    <!-- WhatsApp -->
+                    <a
+                        :href="`https://wa.me/?text=${shareTitle}%20${shareUrl}`"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted"
+                        aria-label="Share on WhatsApp"
+                    >
+                        <svg class="size-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z" />
+                        </svg>
+                        WhatsApp
+                    </a>
+
+                    <!-- BlueSky -->
+                    <a
+                        :href="`https://bsky.app/intent/compose?text=${shareTitle}%20${shareUrl}`"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted"
+                        aria-label="Share on BlueSky"
+                    >
+                        <svg class="size-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479.815 2.736 3.713 3.66 6.383 3.364.136-.02.275-.039.415-.056-.138.022-.276.04-.415.056-3.912.58-7.387 2.005-2.83 7.078 5.013 5.19 6.87-1.113 7.823-4.308.953 3.195 2.05 9.271 7.733 4.308 4.267-4.308 1.172-6.498-2.74-7.078a8.741 8.741 0 0 1-.415-.056c.14.017.279.036.415.056 2.67.297 5.568-.628 6.383-3.364.246-.828.624-5.79.624-6.478 0-.69-.139-1.861-.902-2.204-.659-.298-1.664-.62-4.3 1.24C16.046 4.748 13.087 8.687 12 10.8z" />
+                        </svg>
+                        BlueSky
+                    </a>
+
+                    <!-- Copy link -->
+                    <button
+                        type="button"
+                        class="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted"
+                        aria-label="Copy link"
+                        @click="copyLink"
+                    >
+                        <Check v-if="copied" class="size-4 text-green-500" />
+                        <LinkIcon v-else class="size-4" />
+                        {{ copied ? 'Copied!' : 'Copy link' }}
+                    </button>
+                </div>
+            </section>
 
             <!-- Related posts -->
             <section v-if="relatedPosts.length > 0" class="mt-16">

--- a/resources/js/pages/blog/Show.vue
+++ b/resources/js/pages/blog/Show.vue
@@ -11,6 +11,7 @@ import type { Post } from '@/types';
 defineProps<{
     post: Post;
     relatedPosts: Post[];
+    isPreview?: boolean;
 }>();
 
 </script>
@@ -43,7 +44,15 @@ defineProps<{
         />
     </Head>
 
-    <div class="min-h-screen bg-background">
+    <!-- Preview banner -->
+    <div
+        v-if="isPreview"
+        class="fixed inset-x-0 top-0 z-50 bg-yellow-400 px-4 py-2 text-center text-sm font-medium text-yellow-900"
+    >
+        Preview — this post is not yet published
+    </div>
+
+    <div :class="['min-h-screen bg-background', isPreview && 'pt-10']">
         <BlogHeader max-width="max-w-3xl" />
 
         <main class="mx-auto max-w-3xl px-4 py-10">

--- a/resources/js/pages/blog/Show.vue
+++ b/resources/js/pages/blog/Show.vue
@@ -16,7 +16,32 @@ defineProps<{
 </script>
 
 <template>
-    <Head :title="post.title" />
+    <Head :title="post.meta_title ?? post.title">
+        <meta
+            v-if="post.meta_description ?? post.excerpt"
+            name="description"
+            :content="post.meta_description ?? post.excerpt"
+            head-key="description"
+        />
+        <meta property="og:type" content="article" head-key="og:type" />
+        <meta
+            property="og:title"
+            :content="post.meta_title ?? post.title"
+            head-key="og:title"
+        />
+        <meta
+            v-if="post.meta_description ?? post.excerpt"
+            property="og:description"
+            :content="post.meta_description ?? post.excerpt"
+            head-key="og:description"
+        />
+        <meta
+            v-if="post.featured_image_urls?.large ?? post.featured_image"
+            property="og:image"
+            :content="post.featured_image_urls?.large ?? post.featured_image"
+            head-key="og:image"
+        />
+    </Head>
 
     <div class="min-h-screen bg-background">
         <BlogHeader max-width="max-w-3xl" />

--- a/resources/js/pages/blog/Show.vue
+++ b/resources/js/pages/blog/Show.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Head, Link } from '@inertiajs/vue3';
-import { ArrowLeft, Check, Clock, Copy, Link as LinkIcon } from 'lucide-vue-next';
+import { ArrowLeft, Check, Clock, Link as LinkIcon } from 'lucide-vue-next';
 import { computed, ref } from 'vue';
 import BlogHeader from '@/components/BlogHeader.vue';
 import { Badge } from '@/components/ui/badge';

--- a/resources/js/pages/posts/Edit.vue
+++ b/resources/js/pages/posts/Edit.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { Head, router, useForm } from '@inertiajs/vue3';
-import { CheckCircle } from 'lucide-vue-next';
+import { CheckCircle, ExternalLink } from 'lucide-vue-next';
 import { onBeforeUnmount, ref, watch } from 'vue';
 import { update } from '@/actions/App/Http/Controllers/PostController';
 import PostForm from '@/components/PostForm.vue';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { dashboard } from '@/routes';
-import { autosave, index as postsIndex } from '@/routes/posts';
+import { autosave, index as postsIndex, preview } from '@/routes/posts';
 import type { BreadcrumbItem, Category, Post } from '@/types';
 
 const props = defineProps<{ post: Post; categories: Category[] }>();
@@ -78,16 +78,27 @@ onBeforeUnmount(() => {
         <div class="mx-auto max-w-3xl p-6">
             <div class="mb-6 flex items-center justify-between">
                 <h1 class="text-2xl font-semibold">Edit Post</h1>
-                <span
-                    v-if="autosaveStatus !== 'idle'"
-                    class="flex items-center gap-1.5 text-sm text-muted-foreground"
-                >
-                    <CheckCircle
-                        v-if="autosaveStatus === 'saved'"
-                        class="size-4 text-green-500"
-                    />
-                    {{ autosaveStatus === 'saving' ? 'Saving...' : 'Saved' }}
-                </span>
+                <div class="flex items-center gap-3">
+                    <span
+                        v-if="autosaveStatus !== 'idle'"
+                        class="flex items-center gap-1.5 text-sm text-muted-foreground"
+                    >
+                        <CheckCircle
+                            v-if="autosaveStatus === 'saved'"
+                            class="size-4 text-green-500"
+                        />
+                        {{ autosaveStatus === 'saving' ? 'Saving...' : 'Saved' }}
+                    </span>
+                    <a
+                        :href="preview(post).url"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted"
+                    >
+                        <ExternalLink class="size-4" />
+                        Preview
+                    </a>
+                </div>
             </div>
 
             <PostForm

--- a/resources/js/types/blog.ts
+++ b/resources/js/types/blog.ts
@@ -26,6 +26,7 @@ export type Post = {
     scheduled_at: string | null;
     meta_title: string | null;
     meta_description: string | null;
+    views: number;
     reading_time: number;
     created_at: string;
     updated_at: string;

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,7 +21,9 @@ Route::get('blog/{post:slug}', [BlogController::class, 'show'])->name('blog.show
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', DashboardController::class)->name('dashboard');
 
-    Route::post('posts/upload-image', [PostController::class, 'uploadImage'])->name('posts.upload-image');
+    Route::post('posts/upload-image', [PostController::class, 'uploadImage'])
+        ->name('posts.upload-image')
+        ->middleware('throttle:20,1');
     Route::patch('posts/{post}/autosave', [PostController::class, 'autosave'])
         ->name('posts.autosave')
         ->middleware('throttle:60,1');

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::patch('posts/{post}/autosave', [PostController::class, 'autosave'])
         ->name('posts.autosave')
         ->middleware('throttle:60,1');
+    Route::get('posts/{post}/preview', [PostController::class, 'preview'])
+        ->name('posts.preview');
     Route::resource('posts', PostController::class);
     Route::resource('categories', CategoryController::class)->only(['index', 'store', 'update', 'destroy']);
 });

--- a/tests/Feature/Blog/PostViewCountTest.php
+++ b/tests/Feature/Blog/PostViewCountTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\Blog;
+
+use App\Enums\PostStatus;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class PostViewCountTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+        Cache::flush();
+    }
+
+    public function test_visiting_a_published_post_increments_views(): void
+    {
+        $post = Post::factory()->published()->create(['views' => 0]);
+
+        $this->get(route('blog.show', $post))->assertOk();
+
+        $this->assertDatabaseHas('posts', ['id' => $post->id, 'views' => 1]);
+    }
+
+    public function test_visiting_a_published_post_twice_increments_views_to_two(): void
+    {
+        $post = Post::factory()->published()->create(['views' => 0]);
+
+        $this->get(route('blog.show', $post))->assertOk();
+        $this->get(route('blog.show', $post))->assertOk();
+
+        $this->assertDatabaseHas('posts', ['id' => $post->id, 'views' => 2]);
+    }
+
+    public function test_visiting_preview_route_does_not_increment_views(): void
+    {
+        $author = User::factory()->create();
+        $post = Post::factory()->for($author)->create(['views' => 0, 'status' => PostStatus::Draft]);
+
+        $this->actingAs($author)
+            ->get(route('posts.preview', $post))
+            ->assertOk();
+
+        $this->assertDatabaseHas('posts', ['id' => $post->id, 'views' => 0]);
+    }
+}

--- a/tests/Feature/Posts/PostPreviewTest.php
+++ b/tests/Feature/Posts/PostPreviewTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature\Posts;
+
+use App\Enums\PostStatus;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class PostPreviewTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+    }
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $post = Post::factory()->create();
+
+        $this->get(route('posts.preview', $post))
+            ->assertRedirect(route('login'));
+    }
+
+    public function test_author_can_preview_their_own_draft_post(): void
+    {
+        $user = User::factory()->create();
+        $post = Post::factory()->for($user)->create(['status' => PostStatus::Draft]);
+
+        $this->actingAs($user)
+            ->get(route('posts.preview', $post))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('blog/Show')
+                ->where('isPreview', true)
+                ->where('post.id', $post->id)
+            );
+    }
+
+    public function test_author_can_preview_their_own_published_post(): void
+    {
+        $user = User::factory()->create();
+        $post = Post::factory()->for($user)->create(['status' => PostStatus::Published]);
+
+        $this->actingAs($user)
+            ->get(route('posts.preview', $post))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('blog/Show')
+                ->where('isPreview', true)
+            );
+    }
+
+    public function test_admin_can_preview_any_post(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $post = Post::factory()->for(User::factory()->create())->create(['status' => PostStatus::Draft]);
+
+        $this->actingAs($admin)
+            ->get(route('posts.preview', $post))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('blog/Show')
+                ->where('isPreview', true)
+            );
+    }
+
+    public function test_other_user_cannot_preview_another_users_post(): void
+    {
+        $post = Post::factory()->for(User::factory()->create())->create();
+        $otherUser = User::factory()->create();
+
+        $this->actingAs($otherUser)
+            ->get(route('posts.preview', $post))
+            ->assertForbidden();
+    }
+
+    public function test_preview_renders_related_published_posts(): void
+    {
+        $user = User::factory()->create();
+        $post = Post::factory()->for($user)->create(['status' => PostStatus::Draft]);
+        Post::factory()->for(User::factory()->create())->create(['status' => PostStatus::Published]);
+
+        $this->actingAs($user)
+            ->get(route('posts.preview', $post))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('relatedPosts')
+            );
+    }
+}


### PR DESCRIPTION
Summary
	∙	Fix: missing SEO/OG meta tags — meta_title, meta_description, and Open Graph tags were stored but never rendered in the blog post page head
	∙	Fix: rate limiting on image upload — added throttle:20,1 to the posts.upload-image endpoint
	∙	Security: server-side HTML sanitisation — integrated mews/purifier with a TipTap-compatible profile; post content is purified in StorePostRequest and UpdatePostRequest before hitting the database
	∙	Security: secure HTTP headers — new SecureHeaders middleware adds X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, and Strict-Transport-Security on HTTPS
	∙	Feature: post preview — authors and admins can open an unpublished post in a new tab from the editor; a yellow banner indicates preview mode; the preview route does not count as a view
	∙	Feature: view count — every public blog post visit increments a views counter; the dashboard surfaces a new “Total Views” stat card
	∙	Feature: social share buttons — a share section below each post article provides one-click sharing to X/Twitter, LinkedIn, Facebook, Reddit, WhatsApp, BlueSky, and a copy-link button with clipboard feedback